### PR TITLE
Svg support

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -309,7 +309,7 @@ class ResponsiveImagesUtility implements SingletonInterface
         bool $absoluteUri = false,
         bool $lazyload = false
     ): TagBuilder {
-        $tag = $tag ?: $this->objectManager->get(TagBuilder::class, 'img');
+        $tag = $tag ?: GeneralUtility::makeInstance(TagBuilder::class, 'img');
         $fallbackImage = ($fallbackImage) ?: $originalImage;
 
         // if lazyload enabled add data- prefix

--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -52,6 +52,7 @@ class ResponsiveImagesUtility implements SingletonInterface
      * @param bool          $picturefillMarkup
      * @param bool          $absoluteUri
      * @param  bool         $lazyload
+     * @param  array|string $ignoreFileExtensions
      *
      * @return TagBuilder
      */
@@ -65,9 +66,22 @@ class ResponsiveImagesUtility implements SingletonInterface
         TagBuilder $tag = null,
         bool $picturefillMarkup = true,
         bool $absoluteUri = false,
-        bool $lazyload = false
+        bool $lazyload = false,
+        $ignoreFileExtensions = 'svg'
     ): TagBuilder {
         $tag = $tag ?: GeneralUtility::makeInstance(TagBuilder::class, 'img');
+
+        // Deal with file formats that can't be cropped separately
+        if ($this->hasIgnoredFileExtension($originalImage, $ignoreFileExtensions)) {
+            return $this->createSimpleImageTag(
+                $originalImage,
+                $fallbackImage,
+                $tag,
+                $focusArea,
+                $absoluteUri,
+                $lazyload
+            );
+        }
 
         // Generate fallback image url
         $fallbackImageUri = $this->imageService->getImageUri($fallbackImage, $absoluteUri);
@@ -121,6 +135,7 @@ class ResponsiveImagesUtility implements SingletonInterface
      * @param  bool                  $picturefillMarkup
      * @param  bool                  $absoluteUri
      * @param  bool                  $lazyload
+     * @param  array|string          $ignoreFileExtensions
      *
      * @return TagBuilder
      */
@@ -134,10 +149,23 @@ class ResponsiveImagesUtility implements SingletonInterface
         TagBuilder $fallbackTag = null,
         bool $picturefillMarkup = true,
         bool $absoluteUri = false,
-        bool $lazyload = false
+        bool $lazyload = false,
+        $ignoreFileExtensions = 'svg'
     ): TagBuilder {
         $tag = $tag ?: GeneralUtility::makeInstance(TagBuilder::class, 'picture');
         $fallbackTag = $fallbackTag ?: GeneralUtility::makeInstance(TagBuilder::class, 'img');
+
+        // Deal with file formats that can't be cropped separately
+        if ($this->hasIgnoredFileExtension($originalImage, $ignoreFileExtensions)) {
+            return $this->createSimpleImageTag(
+                $originalImage,
+                $fallbackImage,
+                $fallbackTag,
+                $focusArea,
+                $absoluteUri,
+                $lazyload
+            );
+        }
 
         // Normalize breakpoint configuration
         $breakpoints = $this->normalizeImageBreakpoints($breakpoints);
@@ -259,6 +287,45 @@ class ResponsiveImagesUtility implements SingletonInterface
         }
 
         return $sourceTag;
+    }
+
+    /**
+     * Creates a simple image tag
+     *
+     * @param  FileInterface $image
+     * @param  FileInterface $fallbackImage
+     * @param  TagBuilder    $tag
+     * @param  Area          $focusArea
+     * @param  bool          $absoluteUri
+     * @param  bool          $lazyload
+     *
+     * @return TagBuilder
+     */
+    public function createSimpleImageTag(
+        FileInterface $originalImage,
+        FileInterface $fallbackImage = null,
+        TagBuilder $tag = null,
+        Area $focusArea = null,
+        bool $absoluteUri = false,
+        bool $lazyload = false
+    ): TagBuilder {
+        $tag = $tag ?: $this->objectManager->get(TagBuilder::class, 'img');
+        $fallbackImage = ($fallbackImage) ?: $originalImage;
+
+        // if lazyload enabled add data- prefix
+        $attributePrefix = $lazyload ? 'data-' : '';
+
+        // Set image source
+        $tag->addAttribute($attributePrefix . 'src', $this->imageService->getImageUri($originalImage, $absoluteUri));
+
+        // Set image proportions
+        $tag->addAttribute('width', $fallbackImage->getProperty('width'));
+        $tag->addAttribute('height', $fallbackImage->getProperty('height'));
+
+        // Add metadata to image tag
+        $this->addMetadataToImageTag($tag, $originalImage, $fallbackImage, $focusArea);
+
+        return $tag;
     }
 
     /**
@@ -409,5 +476,20 @@ class ResponsiveImagesUtility implements SingletonInterface
         ksort($breakpoints);
 
         return $breakpoints;
+    }
+
+    /**
+     * Check if the image has a file format that can't be cropped
+     *
+     * @param  FileInterface $image
+     * @param  string        $ignoreFileExtensions
+     *
+     * @return bool
+     */
+    public function hasIgnoredFileExtension(FileInterface $image, $ignoreFileExtensions = 'svg')
+    {
+        $ignoreFileExtensions = (is_array($ignoreFileExtensions))
+            ?: GeneralUtility::trimExplode(',', $ignoreFileExtensions);
+        return in_array($image->getProperty('extension'), $ignoreFileExtensions);
     }
 }

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -38,6 +38,13 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
         $this->registerArgument('breakpoints', 'array', 'Image breakpoints from responsive design.', false);
         $this->registerArgument('picturefill', 'bool', 'Use rendering suggested by picturefill.js', false, true);
         $this->registerArgument('lazyload', 'bool', 'Generate markup that supports lazyloading', false, false);
+        $this->registerArgument(
+            'ignoreFileExtensions',
+            'mixed',
+            'File extensions that won\'t generate responsive images',
+            false,
+            'svg'
+        );
     }
 
     /**
@@ -104,7 +111,8 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
                     $this->tag,
                     $this->arguments['picturefill'],
                     $this->arguments['absolute'],
-                    $this->arguments['lazyload']
+                    $this->arguments['lazyload'],
+                    $this->arguments['ignoreFileExtensions']
                 );
             } else {
                 // Generate img tag with srcset
@@ -118,7 +126,8 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
                     $this->tag,
                     $this->arguments['picturefill'],
                     $this->arguments['absolute'],
-                    $this->arguments['lazyload']
+                    $this->arguments['lazyload'],
+                    $this->arguments['ignoreFileExtensions']
                 );
             }
         } catch (ResourceDoesNotExistException $e) {

--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -39,6 +39,13 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
         $this->registerArgument('breakpoints', 'array', 'Image breakpoints from responsive design.', false);
         $this->registerArgument('picturefill', 'bool', 'Use rendering suggested by picturefill.js', false, true);
         $this->registerArgument('lazyload', 'bool', 'Generate markup that supports lazyloading', false, false);
+        $this->registerArgument(
+            'ignoreFileExtensions',
+            'mixed',
+            'File extensions that won\'t generate responsive images',
+            false,
+            'svg'
+        );
     }
 
     /**
@@ -94,7 +101,8 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
             $this->tag,
             $this->arguments['picturefill'],
             false,
-            $this->arguments['lazyload']
+            $this->arguments['lazyload'],
+            $this->arguments['ignoreFileExtensions']
         );
 
         return $this->tag->render();
@@ -133,7 +141,8 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
             $this->tag,
             $this->arguments['picturefill'],
             false,
-            $this->arguments['lazyload']
+            $this->arguments['lazyload'],
+            $this->arguments['ignoreFileExtensions']
         );
 
         return $this->tag->render();

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
@@ -32,13 +32,17 @@ abstract class AbstractResponsiveImagesUtilityTest extends \TYPO3\CMS\Core\Tests
                 // Simulate processor_allowUpscaling = false
                 $instructions['width'] = min($instructions['width'], $file->getProperty('width'));
 
+                // Use extension from original image
+                $instructions['extension'] = $file->getProperty('extension');
+
                 return $test->mockFileObject($instructions);
             }));
 
         $imageServiceMock
             ->method('getImageUri')
             ->will($this->returnCallback(function ($file, $absolute) {
-                return (($absolute) ? 'http://domain.tld' : '') . '/image@' . $file->getProperty('width') . '.jpg';
+                return (($absolute) ? 'http://domain.tld' : '') . '/image@' . $file->getProperty('width')
+                    . '.' . $file->getProperty('extension');
             }));
 
         return $imageServiceMock;

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
@@ -16,32 +16,32 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             // Test focus area attribute
             'usingFocusArea' => [
                 new TagBuilder('img'),
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new Area(0.4, 0.4, 0.6, 0.6),
                 htmlspecialchars(json_encode(['x' => 400, 'y' => 400, 'width' => 600, 'height' => 600]))
             ],
             // Test fallback to fixed value
             'usingFixedFocusAreaValue' => [
                 $imageTagWithAttribute,
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new Area(0.4, 0.4, 0.6, 0.6),
                 'fixed'
             ],
             // Test omitted parameter
             'withoutFocusArea' => [
                 new TagBuilder('img'),
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 null,
                 null
             ],
             // Test empty focus area
             'withEmptyFocusArea' => [
                 new TagBuilder('img'),
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new Area(0, 0, 1, 1),
                 null
             ]
@@ -72,9 +72,9 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             'usingAltAndTitle' => [
                 new TagBuilder('img'),
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 'image alt',
                 'image title'
             ],
@@ -82,17 +82,17 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             'usingFixedAltAndTitleValues' => [
                 $imageTagWithAttributes,
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 'fixed alt',
                 'fixed title'
             ],
             // Test default alt/title attributes
             'withoutAltAndTitle' => [
                 new TagBuilder('img'),
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 '',
                 null
             ]
@@ -120,7 +120,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test high dpi image srcset
             'usingHighDpi' => [
-                $this->mockFileObject(['width' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'extension' => 'jpg']),
                 400,
                 ['1x', '2x'],
                 null,
@@ -129,7 +129,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test responsive image srcset (widths in integers)
             'usingResponsiveWidths' => [
-                $this->mockFileObject(['width' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'extension' => 'jpg']),
                 400,
                 [200, 400, 600],
                 null,
@@ -138,7 +138,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test responsive image srcset (widths as strings)
             'usingResponsiveWidthsAsStrings' => [
-                $this->mockFileObject(['width' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'extension' => 'jpg']),
                 400,
                 ['200w', '400w', '600w'],
                 null,
@@ -147,7 +147,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test absolute urls
             'requestingAbsoluteUrls' => [
-                $this->mockFileObject(['width' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'extension' => 'jpg']),
                 400,
                 ['200w', '400w', '600w'],
                 null,
@@ -160,7 +160,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test srcset input as string
             'usingSrcsetString' => [
-                $this->mockFileObject(['width' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'extension' => 'jpg']),
                 400,
                 '200, 400, 600',
                 null,
@@ -172,7 +172,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 ]
             ],
             'usingTooSmallImage' => [
-                $this->mockFileObject(['width' => 400]),
+                $this->mockFileObject(['width' => 400, 'extension' => 'jpg']),
                 400,
                 '200, 300, 500',
                 null,

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
@@ -7,6 +7,21 @@ use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
 
 class ImageTagTest extends AbstractResponsiveImagesUtilityTest
 {
+    public function createSimpleImageTagProvider()
+    {
+        // TODO
+    }
+
+    /**
+     * @test
+     * @dataProvider createSimpleImageTagProvider
+     */
+    public function createSimpleImageTag()
+    {
+        // TODO
+        //$this->utility->createSimpleImageTag();
+    }
+
     public function createImageTagWithSrcsetUsingEmptySrcsetProvider()
     {
         return [
@@ -83,6 +98,15 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 ['1x', '2x'],
                 null,
                 '/image@1000.jpg 1x, /image@2000.jpg 2x',
+                true
+            ],
+            // Test svg image
+            'usingSvg' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'svg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
+                [100, 200, 300],
+                '/image@2000.svg',
+                null,
                 true
             ]
         ];
@@ -204,6 +228,15 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 'image alt',
                 'image title'
+            ],
+            // Test svg image metadata attributes
+            'usingMetadataWithSvg' => [
+                $this->mockFileObject(
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'svg']
+                ),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
+                'image alt',
+                'image title'
             ]
         ];
     }
@@ -233,6 +266,15 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                     ['width' => 2000, 'height' => 2000, 'alt' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                $customTag,
+                'fixed alt',
+                'long description'
+            ],
+            'usingCustomTagWithSvg' => [
+                $this->mockFileObject(
+                    ['width' => 2000, 'height' => 2000, 'alt' => 'image alt', 'title' => 'image title', 'extension' => 'svg']
+                ),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
                 $customTag,
                 'fixed alt',
                 'long description'
@@ -287,6 +329,17 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 null,
                 null,
                 '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
+                true
+            ],
+            // Test svg image
+            'withSvgImage' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'svg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
+                [400, 800],
+                null,
+                null,
+                '/image@2000.svg',
+                null,
                 true
             ]
         ];

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
@@ -9,17 +9,128 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
 {
     public function createSimpleImageTagProvider()
     {
-        // TODO
+        return [
+            'simple' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                null,
+                null,
+                false,
+                false,
+                'img',
+                '/image@2000.jpg',
+                null,
+                null,
+                null,
+                null
+            ],
+            'usingMetadata' => [
+                $this->mockFileObject(
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
+                ),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                null,
+                null,
+                false,
+                false,
+                'img',
+                '/image@2000.jpg',
+                null,
+                null,
+                'image alt',
+                'image title'
+            ],
+            'usingPredefinedTag' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                new TagBuilder('img-test'),
+                null,
+                false,
+                false,
+                'img-test',
+                '/image@2000.jpg',
+                null,
+                null,
+                null,
+                null
+            ],
+            'usingFocusArea' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                null,
+                new Area(0.4, 0.4, 0.6, 0.6),
+                false,
+                false,
+                'img',
+                '/image@2000.jpg',
+                null,
+                htmlspecialchars(json_encode(['x' => 400, 'y' => 400, 'width' => 600, 'height' => 600])),
+                null,
+                null
+            ],
+            'usingAbsoluteUri' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                null,
+                null,
+                true,
+                false,
+                'img',
+                'http://domain.tld/image@2000.jpg',
+                null,
+                null,
+                null,
+                null
+            ],
+            'usingLazyload' => [
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
+                null,
+                null,
+                false,
+                true,
+                'img',
+                null,
+                '/image@2000.jpg',
+                null,
+                null,
+                null
+            ]
+        ];
     }
 
     /**
      * @test
      * @dataProvider createSimpleImageTagProvider
      */
-    public function createSimpleImageTag()
-    {
-        // TODO
-        //$this->utility->createSimpleImageTag();
+    public function createSimpleImageTag(
+        $originalImage,
+        $fallbackImage,
+        $tag,
+        $focusArea,
+        $absoluteUri,
+        $lazyload,
+        $tagName,
+        $srcAttribute,
+        $dataSrcAttribute,
+        $dataFocusAreaAttribute,
+        $altAttribute,
+        $titleAttribute
+    ) {
+        $tag = $this->utility->createSimpleImageTag(
+            $originalImage,
+            $fallbackImage,
+            $tag,
+            $focusArea,
+            $absoluteUri,
+            $lazyload
+        );
+        $this->assertEquals($tagName, $tag->getTagName());
+        $this->assertEquals($srcAttribute, $tag->getAttribute('src'));
+        $this->assertEquals($dataSrcAttribute, $tag->getAttribute('data-src'));
+        $this->assertEquals($dataFocusAreaAttribute, $tag->getAttribute('data-focus-area'));
+        $this->assertEquals($altAttribute, $tag->getAttribute('alt'));
+        $this->assertEquals($titleAttribute, $tag->getAttribute('title'));
     }
 
     public function createImageTagWithSrcsetUsingEmptySrcsetProvider()

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
@@ -12,8 +12,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test plain tag
             'usingEmptySrcset' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [],
                 'img',
                 1000,
@@ -51,8 +51,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test standard output (instead of picturefill output)
             'usingStandardOutput' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400],
                 '/image@1000.jpg',
                 '/image@400.jpg 400w, /image@1000.jpg 1000w',
@@ -60,8 +60,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test srcset with 3 widths, one having same width as fallback
             'usingThreeWidthsWithFallbackDuplicate' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400, 800, 1000],
                 null,
                 '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
@@ -69,8 +69,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test srcset with 2 widths + fallback image
             'usingTwoWidthsWithoutFallbackDuplicate' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400, 800],
                 null,
                 '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
@@ -78,8 +78,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test high dpi
             'usingHighDpi' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 ['1x', '2x'],
                 null,
                 '/image@1000.jpg 1x, /image@2000.jpg 2x',
@@ -118,8 +118,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
     {
         return [
             'usingFocusArea' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new Area(0.4, 0.4, 0.6, 0.6),
                 htmlspecialchars(json_encode(['x' => 400, 'y' => 400, 'width' => 600, 'height' => 600]))
             ]
@@ -146,24 +146,24 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test sizes attribute
             'usingStaticQuery' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400],
                 'sizes query',
                 'sizes query'
             ],
             // Test sizes attribute with dynamic width
             'usingDynamicQuery' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400],
                 '%1$d',
                 1000
             ],
             // Test sizes attribute for high dpi setup
             'usingHighDpi' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 ['1x', '2x'],
                 '%1$d',
                 null
@@ -199,9 +199,9 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
             // Test image metadata attributes
             'usingMetadata' => [
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 'image alt',
                 'image title'
             ]
@@ -230,9 +230,9 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             'usingCustomTag' => [
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alt' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alt' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 $customTag,
                 'fixed alt',
                 'long description'
@@ -269,8 +269,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test standard output (instead of picturefill output)
             'usingStandardOutput' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400],
                 null,
                 null,
@@ -280,8 +280,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test srcset with 2 widths + fallback image
             'usingTwoWidthsWithoutFallbackDuplicate' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400, 800],
                 null,
                 null,

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/PictureSourceTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/PictureSourceTagTest.php
@@ -9,7 +9,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test empty srcset
             'usingEmptySrcset' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 1000,
                 [],
                 '',
@@ -20,7 +20,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test high dpi srcset
             'usingHighDpi' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 1000,
                 ['1x', '2x'],
                 '',
@@ -31,7 +31,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test responsive images srcset
             'usingResponsiveWidths' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 1000,
                 [400, 800],
                 '',
@@ -42,7 +42,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test dynamic sizes query
             'usingDynamicSizesQuery' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 1000,
                 [400],
                 'media query',
@@ -53,7 +53,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test absolute urls
             'requestingAbsoluteUrls' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 1000,
                 ['1x', '2x'],
                 '',

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
@@ -19,8 +19,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test two breakpoints with media queries
             'usingTwoBreakpointsWithMedia' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -48,8 +48,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test two breakpoints with media queries with standard output
             'usingTwoBreakpointsWithMediaRequestingStandardOutput' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -77,8 +77,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test two breakpoints, last one without media query
             'usingTwoBreakpointsLastWithoutMedia' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -104,8 +104,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test two breakpoints, last one without media query, with standard output
             'usingTwoBreakpointsLastWithoutMediaRequestingStandardOutput' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -128,8 +128,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test focus area
             'usingFocusArea' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [],
                 $cropVariantCollection,
                 new Area(0.4, 0.4, 0.6, 0.6),
@@ -145,9 +145,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             // Test image metadata attributes
             'usingMetadata' => [
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [],
                 $cropVariantCollection,
                 null,
@@ -160,8 +160,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test lazyload markup
             'usingLazyload' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -183,8 +183,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Test lazyload markup with standard output
             'usingLazyloadRequestingStandardOutput' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [
                     [
                         'cropVariant' => 'desktop',
@@ -247,8 +247,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
         return [
             // Test if tag attributes persist
             'usingCustomTag' => [
-                $this->mockFileObject(['width' => 2000, 'height' => 2000]),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new CropVariantCollection([]),
                 $pictureTag,
                 'picture-custom',
@@ -292,9 +292,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
             // Test if fallback tag attributes persist
             'usingCustomFallbackTag' => [
                 $this->mockFileObject(
-                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title']
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'jpg']
                 ),
-                $this->mockFileObject(['width' => 1000, 'height' => 1000]),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new CropVariantCollection([]),
                 $fallbackTag,
                 ['<img alt="fixed alt" title="fixed title" longdesc="fixed longdesc" srcset="/image@1000.jpg" width="1000" />']

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
@@ -324,4 +324,41 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
         );
         $this->assertEquals(implode('', $tagContent), $tag->getContent());
     }
+
+    public function createPictureTagFromSvgProvider()
+    {
+        return [
+            // Test if fallback tag attributes persist
+            'withSvgImage' => [
+                $this->mockFileObject(
+                    ['width' => 2000, 'height' => 2000, 'alternative' => 'image alt', 'title' => 'image title', 'extension' => 'svg']
+                ),
+                $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
+                'img',
+                '/image@2000.svg',
+                null,
+                1000,
+                1000
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider createPictureTagFromSvgProvider
+     */
+    public function createPictureTagFromSvg($originalImage, $fallbackImage, $tagName, $srcAttribute, $srcsetAttribute, $heightAttribute, $widthAttribute)
+    {
+        $tag = $this->utility->createPictureTag(
+            $originalImage,
+            $fallbackImage,
+            [],
+            new CropVariantCollection([])
+        );
+        $this->assertEquals($tagName, $tag->getTagName());
+        $this->assertEquals($srcAttribute, $tag->getAttribute('src'));
+        $this->assertEquals($srcsetAttribute, $tag->getAttribute('srcset'));
+        $this->assertEquals($widthAttribute, $tag->getAttribute('width'));
+        $this->assertEquals($heightAttribute, $tag->getAttribute('height'));
+    }
 }


### PR DESCRIPTION
Previously, SVGs were converted to png files while generating responsive images. Now, the original file will be used and no responsive images will be generated.