### PR TITLE
Fix array usage of ResponsiveImagesUtility::hasIgnoredFileExtension()

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -482,14 +482,16 @@ class ResponsiveImagesUtility implements SingletonInterface
      * Check if the image has a file format that can't be cropped
      *
      * @param  FileInterface $image
-     * @param  string        $ignoreFileExtensions
+     * @param  array|string  $ignoreFileExtensions
      *
      * @return bool
      */
     public function hasIgnoredFileExtension(FileInterface $image, $ignoreFileExtensions = 'svg')
     {
         $ignoreFileExtensions = (is_array($ignoreFileExtensions))
-            ?: GeneralUtility::trimExplode(',', $ignoreFileExtensions);
+            ? $ignoreFileExtensions 
+            : GeneralUtility::trimExplode(',', $ignoreFileExtensions);
+        
         return in_array($image->getProperty('extension'), $ignoreFileExtensions);
     }
 }

--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -489,9 +489,9 @@ class ResponsiveImagesUtility implements SingletonInterface
     public function hasIgnoredFileExtension(FileInterface $image, $ignoreFileExtensions = 'svg')
     {
         $ignoreFileExtensions = (is_array($ignoreFileExtensions))
-            ? $ignoreFileExtensions 
+            ? $ignoreFileExtensions
             : GeneralUtility::trimExplode(',', $ignoreFileExtensions);
-        
+
         return in_array($image->getProperty('extension'), $ignoreFileExtensions);
     }
 }


### PR DESCRIPTION
Previously, the result of `is_array($ignoreFileExtensions)` was used as the new value of `$ignoreFileExtensions` in case the parameter was an array, which would break the following `in_array(...)` statement.