### PR TITLE
Feature/processed files

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -93,10 +93,15 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
             // Generate fallback image
             $processingInstructions = [
                 'width' => $this->arguments['width'],
-                'minWidth' => $this->arguments['minWidth'],
-                'maxWidth' => $this->arguments['maxWidth'],
                 'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
             ];
+            // Set min/maxWidth only if they are given
+            if (!is_null($this->arguments['minWidth'])) {
+                $processingInstructions['minWidth'] = $this->arguments['minWidth'];
+            }
+            if (!is_null($this->arguments['maxWidth'])) {
+                $processingInstructions['maxWidth'] = $this->arguments['maxWidth'];
+            }
             $fallbackImage = $this->imageService->applyProcessingInstructions($image, $processingInstructions);
 
             if ($this->arguments['breakpoints']) {


### PR DESCRIPTION
Currently the processing instructions differ for the fallback and the srcset images. The processing instructions contain additional entries for minWidth and maxWidth, even if they are not set in the tag. This causes typo3 to create two identical processed images for the same image width.
I changed the processing instructions for the fallback image to contain the minWidth and maxWidth only if they are given. This way the fallback image does not create an additional entry in the processed files table.