### PR TITLE
[BUGFIX] Fix #45: bad srcset is generated for some images

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -456,15 +456,24 @@ class ResponsiveImagesUtility implements SingletonInterface
     {
         $srcsetString = [];
         foreach ($srcsetImages as $widthDescriptor => $imageCandidate) {
-            $path = parse_url($imageCandidate, PHP_URL_PATH);
-            $segments = explode('/', $path);
-            array_walk($segments, function (&$segment) {
-                $segment = rawurlencode($segment);
-            });
-            $imageCandidate = str_replace($path, implode('/', $segments), $imageCandidate);
-            $srcsetString[] = $imageCandidate . ' ' . $widthDescriptor;
+            $srcsetString[] = $this->sanitizeSrcsetUrl($imageCandidate) . ' ' . $widthDescriptor;
         }
         return implode(', ', $srcsetString);
+    }
+
+    /**
+     * Ensures that the provided url can be used safely in a srcset attribute
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    public function sanitizeSrcsetUrl(string $url): string
+    {
+        return strtr($url, [
+            ' ' => '%20',
+            ',' => '%2C'
+        ]);
     }
 
     /**

--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -456,6 +456,12 @@ class ResponsiveImagesUtility implements SingletonInterface
     {
         $srcsetString = [];
         foreach ($srcsetImages as $widthDescriptor => $imageCandidate) {
+            $path = parse_url($imageCandidate, PHP_URL_PATH);
+            $segments = explode('/', $path);
+            array_walk($segments, function(&$segment) {
+                $segment = rawurlencode($segment);
+            });
+            $imageCandidate = str_replace($path, implode('/', $segments), $imageCandidate);
             $srcsetString[] = $imageCandidate . ' ' . $widthDescriptor;
         }
         return implode(', ', $srcsetString);

--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -458,7 +458,7 @@ class ResponsiveImagesUtility implements SingletonInterface
         foreach ($srcsetImages as $widthDescriptor => $imageCandidate) {
             $path = parse_url($imageCandidate, PHP_URL_PATH);
             $segments = explode('/', $path);
-            array_walk($segments, function(&$segment) {
+            array_walk($segments, function (&$segment) {
                 $segment = rawurlencode($segment);
             });
             $imageCandidate = str_replace($path, implode('/', $segments), $imageCandidate);

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
@@ -41,7 +41,7 @@ abstract class AbstractResponsiveImagesUtilityTest extends \TYPO3\CMS\Core\Tests
         $imageServiceMock
             ->method('getImageUri')
             ->will($this->returnCallback(function ($file, $absolute) {
-                return (($absolute) ? 'http://domain.tld' : '') . '/image@' . $file->getProperty('width')
+                return (($absolute) ? 'http://domain.tld' : '') . '/image-' . $file->getProperty('width')
                     . '.' . $file->getProperty('extension');
             }));
 

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/AbstractResponsiveImagesUtilityTest.php
@@ -32,7 +32,8 @@ abstract class AbstractResponsiveImagesUtilityTest extends \TYPO3\CMS\Core\Tests
                 // Simulate processor_allowUpscaling = false
                 $instructions['width'] = min($instructions['width'], $file->getProperty('width'));
 
-                // Use extension from original image
+                // Use file name and extension from original image
+                $instructions['name'] = $file->getProperty('name');
                 $instructions['extension'] = $file->getProperty('extension');
 
                 return $test->mockFileObject($instructions);
@@ -41,7 +42,7 @@ abstract class AbstractResponsiveImagesUtilityTest extends \TYPO3\CMS\Core\Tests
         $imageServiceMock
             ->method('getImageUri')
             ->will($this->returnCallback(function ($file, $absolute) {
-                return (($absolute) ? 'http://domain.tld' : '') . '/image-' . $file->getProperty('width')
+                return (($absolute) ? 'http://domain.tld' : '') . '/' . $file->getProperty('name') . '-' . $file->getProperty('width')
                     . '.' . $file->getProperty('extension');
             }));
 
@@ -50,6 +51,11 @@ abstract class AbstractResponsiveImagesUtilityTest extends \TYPO3\CMS\Core\Tests
 
     protected function mockFileObject($properties)
     {
+        $defaultProperties = [
+            'name' => 'image'
+        ];
+        $properties = array_replace($defaultProperties, $properties);
+
         $fileMock = $this->getMockBuilder(FileReference::class)
             ->disableOriginalConstructor()
             ->setMethods(['getProperty'])

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
@@ -182,6 +182,17 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                     '300w' => '/image-300.jpg',
                     '400w' => '/image-400.jpg'
                 ]
+            ],
+            // Test if special characters are kept in file name
+            'usingSpecialCharactersInFileName' => [
+                $this->mockFileObject(['name' => 'this/is a/filename@with-/special!charac,ters', 'width' => 400, 'extension' => 'jpg']),
+                400,
+                [200],
+                null,
+                false,
+                [
+                    '200w' => '/this/is a/filename@with-/special!charac,ters-200.jpg'
+                ]
             ]
         ];
     }
@@ -221,6 +232,14 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             'usingMultipleSrcsetItems' => [
                 ['200w' => 'image-200.jpg', '400w' => 'image-400.jpg', '600w' => 'image-600.jpg'],
                 'image-200.jpg 200w, image-400.jpg 400w, image-600.jpg 600w'
+            ],
+            // Test if special characters are encoded in file name
+            'usingSpecialCharactersInFileName' => [
+                [
+                    '200w' => 'this/is a/filename@with-/special!charac,ters-200.jpg',
+                    '400w' => 'this/is a/filename@with-/special!charac,ters-400.jpg'
+                ],
+                'this/is%20a/filename@with-/special!charac%2Cters-200.jpg 200w, this/is%20a/filename@with-/special!charac%2Cters-400.jpg 400w'
             ]
         ];
     }

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/HelpersTest.php
@@ -125,7 +125,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 ['1x', '2x'],
                 null,
                 false,
-                ['1x' => '/image@400.jpg', '2x' => '/image@800.jpg']
+                ['1x' => '/image-400.jpg', '2x' => '/image-800.jpg']
             ],
             // Test responsive image srcset (widths in integers)
             'usingResponsiveWidths' => [
@@ -134,7 +134,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 [200, 400, 600],
                 null,
                 false,
-                ['200w' => '/image@200.jpg', '400w' => '/image@400.jpg', '600w' => '/image@600.jpg']
+                ['200w' => '/image-200.jpg', '400w' => '/image-400.jpg', '600w' => '/image-600.jpg']
             ],
             // Test responsive image srcset (widths as strings)
             'usingResponsiveWidthsAsStrings' => [
@@ -143,7 +143,7 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 ['200w', '400w', '600w'],
                 null,
                 false,
-                ['200w' => '/image@200.jpg', '400w' => '/image@400.jpg', '600w' => '/image@600.jpg']
+                ['200w' => '/image-200.jpg', '400w' => '/image-400.jpg', '600w' => '/image-600.jpg']
             ],
             // Test absolute urls
             'requestingAbsoluteUrls' => [
@@ -153,9 +153,9 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 null,
                 true,
                 [
-                    '200w' => 'http://domain.tld/image@200.jpg',
-                    '400w' => 'http://domain.tld/image@400.jpg',
-                    '600w' => 'http://domain.tld/image@600.jpg'
+                    '200w' => 'http://domain.tld/image-200.jpg',
+                    '400w' => 'http://domain.tld/image-400.jpg',
+                    '600w' => 'http://domain.tld/image-600.jpg'
                 ]
             ],
             // Test srcset input as string
@@ -166,9 +166,9 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 null,
                 true,
                 [
-                    '200w' => 'http://domain.tld/image@200.jpg',
-                    '400w' => 'http://domain.tld/image@400.jpg',
-                    '600w' => 'http://domain.tld/image@600.jpg'
+                    '200w' => 'http://domain.tld/image-200.jpg',
+                    '400w' => 'http://domain.tld/image-400.jpg',
+                    '600w' => 'http://domain.tld/image-600.jpg'
                 ]
             ],
             'usingTooSmallImage' => [
@@ -178,9 +178,9 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
                 null,
                 false,
                 [
-                    '200w' => '/image@200.jpg',
-                    '300w' => '/image@300.jpg',
-                    '400w' => '/image@400.jpg'
+                    '200w' => '/image-200.jpg',
+                    '300w' => '/image-300.jpg',
+                    '400w' => '/image-400.jpg'
                 ]
             ]
         ];
@@ -214,13 +214,13 @@ class HelpersTest extends AbstractResponsiveImagesUtilityTest
             ],
             // Check srcset with single image
             'usingSingleSrcsetItem' => [
-                ['1x' => 'image@1x.jpg'],
-                'image@1x.jpg 1x'
+                ['1x' => 'image-1x.jpg'],
+                'image-1x.jpg 1x'
             ],
             // Check srcset with multiple images
             'usingMultipleSrcsetItems' => [
-                ['200w' => 'image@200.jpg', '400w' => 'image@400.jpg', '600w' => 'image@600.jpg'],
-                'image@200.jpg 200w, image@400.jpg 400w, image@600.jpg 600w'
+                ['200w' => 'image-200.jpg', '400w' => 'image-400.jpg', '600w' => 'image-600.jpg'],
+                'image-200.jpg 200w, image-400.jpg 400w, image-600.jpg 600w'
             ]
         ];
     }

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/ImageTagTest.php
@@ -18,7 +18,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 false,
                 'img',
-                '/image@2000.jpg',
+                '/image-2000.jpg',
                 null,
                 null,
                 null,
@@ -34,7 +34,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 false,
                 'img',
-                '/image@2000.jpg',
+                '/image-2000.jpg',
                 null,
                 null,
                 'image alt',
@@ -48,7 +48,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 false,
                 'img-test',
-                '/image@2000.jpg',
+                '/image-2000.jpg',
                 null,
                 null,
                 null,
@@ -62,7 +62,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 false,
                 'img',
-                '/image@2000.jpg',
+                '/image-2000.jpg',
                 null,
                 htmlspecialchars(json_encode(['x' => 400, 'y' => 400, 'width' => 600, 'height' => 600])),
                 null,
@@ -76,7 +76,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 true,
                 false,
                 'img',
-                'http://domain.tld/image@2000.jpg',
+                'http://domain.tld/image-2000.jpg',
                 null,
                 null,
                 null,
@@ -91,7 +91,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 true,
                 'img',
                 null,
-                '/image@2000.jpg',
+                '/image-2000.jpg',
                 null,
                 null,
                 null
@@ -145,7 +145,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 1000,
                 1000,
                 null,
-                '/image@1000.jpg 1000w'
+                '/image-1000.jpg 1000w'
             ]
         ];
     }
@@ -180,8 +180,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'jpg']),
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400],
-                '/image@1000.jpg',
-                '/image@400.jpg 400w, /image@1000.jpg 1000w',
+                '/image-1000.jpg',
+                '/image-400.jpg 400w, /image-1000.jpg 1000w',
                 false
             ],
             // Test srcset with 3 widths, one having same width as fallback
@@ -190,7 +190,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400, 800, 1000],
                 null,
-                '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
+                '/image-400.jpg 400w, /image-800.jpg 800w, /image-1000.jpg 1000w',
                 true
             ],
             // Test srcset with 2 widths + fallback image
@@ -199,7 +199,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 [400, 800],
                 null,
-                '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
+                '/image-400.jpg 400w, /image-800.jpg 800w, /image-1000.jpg 1000w',
                 true
             ],
             // Test high dpi
@@ -208,7 +208,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 ['1x', '2x'],
                 null,
-                '/image@1000.jpg 1x, /image@2000.jpg 2x',
+                '/image-1000.jpg 1x, /image-2000.jpg 2x',
                 true
             ],
             // Test svg image
@@ -216,7 +216,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 2000, 'height' => 2000, 'extension' => 'svg']),
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
                 [100, 200, 300],
-                '/image@2000.svg',
+                '/image-2000.svg',
                 null,
                 true
             ]
@@ -427,8 +427,8 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 [400],
                 null,
                 null,
-                '/image@1000.jpg',
-                '/image@400.jpg 400w, /image@1000.jpg 1000w',
+                '/image-1000.jpg',
+                '/image-400.jpg 400w, /image-1000.jpg 1000w',
                 false
             ],
             // Test srcset with 2 widths + fallback image
@@ -439,7 +439,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 null,
                 null,
                 null,
-                '/image@400.jpg 400w, /image@800.jpg 800w, /image@1000.jpg 1000w',
+                '/image-400.jpg 400w, /image-800.jpg 800w, /image-1000.jpg 1000w',
                 true
             ],
             // Test svg image
@@ -449,7 +449,7 @@ class ImageTagTest extends AbstractResponsiveImagesUtilityTest
                 [400, 800],
                 null,
                 null,
-                '/image@2000.svg',
+                '/image-2000.svg',
                 null,
                 true
             ]

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/PictureSourceTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/PictureSourceTagTest.php
@@ -26,7 +26,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
                 '',
                 '',
                 false,
-                '/image@1000.jpg 1x, /image@2000.jpg 2x',
+                '/image-1000.jpg 1x, /image-2000.jpg 2x',
                 null
             ],
             // Test responsive images srcset
@@ -37,7 +37,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
                 '',
                 '',
                 false,
-                '/image@400.jpg 400w, /image@800.jpg 800w',
+                '/image-400.jpg 400w, /image-800.jpg 800w',
                 null
             ],
             // Test dynamic sizes query
@@ -48,7 +48,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
                 'media query',
                 '%d',
                 false,
-                '/image@400.jpg 400w',
+                '/image-400.jpg 400w',
                 1000
             ],
             // Test absolute urls
@@ -59,7 +59,7 @@ class PictureSourceTagTest extends AbstractResponsiveImagesUtilityTest
                 '',
                 '',
                 true,
-                'http://domain.tld/image@1000.jpg 1x, http://domain.tld/image@2000.jpg 2x',
+                'http://domain.tld/image-1000.jpg 1x, http://domain.tld/image-2000.jpg 2x',
                 null
             ],
         ];

--- a/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
+++ b/Tests/Unit/Utility/ResponsiveImagesUtility/PictureTagTest.php
@@ -41,9 +41,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<source srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<source srcset="/image@400.jpg 400w, /image@800.jpg 800w" media="media mobile" sizes="sizes mobile" />',
-                    '<img srcset="/image@1000.jpg" width="1000" alt="" />'
+                    '<source srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<source srcset="/image-400.jpg 400w, /image-800.jpg 800w" media="media mobile" sizes="sizes mobile" />',
+                    '<img srcset="/image-1000.jpg" width="1000" alt="" />'
                 ]
             ],
             // Test two breakpoints with media queries with standard output
@@ -70,9 +70,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<source srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<source srcset="/image@400.jpg 400w, /image@800.jpg 800w" media="media mobile" sizes="sizes mobile" />',
-                    '<img src="/image@1000.jpg" width="1000" alt="" />'
+                    '<source srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<source srcset="/image-400.jpg 400w, /image-800.jpg 800w" media="media mobile" sizes="sizes mobile" />',
+                    '<img src="/image-1000.jpg" width="1000" alt="" />'
                 ]
             ],
             // Test two breakpoints, last one without media query
@@ -98,8 +98,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<source srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<img srcset="/image@400.jpg 400w, /image@800.jpg 800w" sizes="sizes mobile" width="1000" alt="" />'
+                    '<source srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<img srcset="/image-400.jpg 400w, /image-800.jpg 800w" sizes="sizes mobile" width="1000" alt="" />'
                 ]
             ],
             // Test two breakpoints, last one without media query, with standard output
@@ -121,9 +121,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<source srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<source srcset="/image@400.jpg 400w, /image@800.jpg 800w" sizes="sizes mobile" />',
-                    '<img src="/image@1000.jpg" width="1000" alt="" />'
+                    '<source srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<source srcset="/image-400.jpg 400w, /image-800.jpg 800w" sizes="sizes mobile" />',
+                    '<img src="/image-1000.jpg" width="1000" alt="" />'
                 ]
             ],
             // Test focus area
@@ -137,7 +137,7 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<img srcset="/image@1000.jpg" width="1000" data-focus-area="'
+                    '<img srcset="/image-1000.jpg" width="1000" data-focus-area="'
                         . htmlspecialchars(json_encode(['x' => 400, 'y' => 400, 'width' => 600, 'height' => 600]))
                         . '" alt="" />'
                 ]
@@ -155,7 +155,7 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 false,
                 'picture',
                 [
-                    '<img srcset="/image@1000.jpg" width="1000" alt="image alt" title="image title" />'
+                    '<img srcset="/image-1000.jpg" width="1000" alt="image alt" title="image title" />'
                 ]
             ],
             // Test lazyload markup
@@ -177,8 +177,8 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 true,
                 'picture',
                 [
-                    '<source data-srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<img data-srcset="/image@400.jpg 400w, /image@800.jpg 800w" sizes="sizes mobile" width="1000" alt="" />'
+                    '<source data-srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<img data-srcset="/image-400.jpg 400w, /image-800.jpg 800w" sizes="sizes mobile" width="1000" alt="" />'
                 ]
             ],
             // Test lazyload markup with standard output
@@ -200,9 +200,9 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 true,
                 'picture',
                 [
-                    '<source data-srcset="/image@500.jpg 500w, /image@1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
-                    '<source data-srcset="/image@400.jpg 400w, /image@800.jpg 800w" sizes="sizes mobile" />',
-                    '<img data-src="/image@1000.jpg" width="1000" alt="" />'
+                    '<source data-srcset="/image-500.jpg 500w, /image-1000.jpg 1000w" media="media desktop" sizes="sizes desktop" />',
+                    '<source data-srcset="/image-400.jpg 400w, /image-800.jpg 800w" sizes="sizes mobile" />',
+                    '<img data-src="/image-1000.jpg" width="1000" alt="" />'
                 ]
             ]
         ];
@@ -297,7 +297,7 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'jpg']),
                 new CropVariantCollection([]),
                 $fallbackTag,
-                ['<img alt="fixed alt" title="fixed title" longdesc="fixed longdesc" srcset="/image@1000.jpg" width="1000" />']
+                ['<img alt="fixed alt" title="fixed title" longdesc="fixed longdesc" srcset="/image-1000.jpg" width="1000" />']
             ]
         ];
     }
@@ -335,7 +335,7 @@ class PictureTagTest extends AbstractResponsiveImagesUtilityTest
                 ),
                 $this->mockFileObject(['width' => 1000, 'height' => 1000, 'extension' => 'svg']),
                 'img',
-                '/image@2000.svg',
+                '/image-2000.svg',
                 null,
                 1000,
                 1000


### PR DESCRIPTION
Fixes the issue by encoding every segment of the image path.