### PR TITLE
Typo3 10 compatibility: use new TYPO3Fluid namespace

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -6,7 +6,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\CropVariantCollection;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
-use TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder;
+use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -6,7 +6,7 @@ use TYPO3\CMS\Core\Imaging\ImageManipulation\CropVariantCollection;
 use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 use SMS\SmsResponsiveImages\Utility\ResponsiveImagesUtility;
 
-class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
+class ImageViewHelper extends \TYPO3Fluid\Fluid\ViewHelpers\ImageViewHelper
 {
     /**
      * @var ResponsiveImagesUtility
@@ -54,7 +54,7 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
      *
      * @see https://docs.typo3.org/typo3cms/TyposcriptReference/ContentObjects/Image/
      *
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+     * @throws \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      * @return string Rendered tag
      */
     public function render()
@@ -62,7 +62,7 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
         if ((is_null($this->arguments['src']) && is_null($this->arguments['image']))
             || (!is_null($this->arguments['src']) && !is_null($this->arguments['image']))
         ) {
-            throw new \TYPO3\CMS\Fluid\Core\ViewHelper\Exception(
+            throw new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception(
                 'You must either specify a string src or a File object.',
                 1517766588 // Original code: 1382284106
             );

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '1.3.0',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '8.7.0-9.9.99',
+            'typo3' => '8.7.0-10.9.99',
             'fluid' => '',
             'php' => '7.0.0-0.0.0'
         ),


### PR DESCRIPTION
- see Typo3 deprecation 87277
- mark as Typo3 10.x compatible