### PR TITLE
[BUGFIX]	added fileExtension as parameter in renderImage func, as par…

### DIFF
--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -67,17 +67,17 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
      * @param  FileInterface $image
      * @param  string        $width
      * @param  string        $height
-     *
+     * @param string|null $fileExtension
      * @return string                 Rendered img tag
      */
-    protected function renderImage(FileInterface $image, $width, $height)
+    protected function renderImage(FileInterface $image, $width, $height, ?string $fileExtension)
     {
         if ($this->arguments['breakpoints']) {
             return $this->renderPicture($image, $width, $height);
         } elseif ($this->arguments['srcset']) {
             return $this->renderImageSrcset($image, $width, $height);
         } else {
-            return parent::renderImage($image, $width, $height);
+            return parent::renderImage($image, $width, $height, $fileExtension);
         }
     }
 


### PR DESCRIPTION
Hi everbody!
Affected installation: TYPO3 V 10.3.0

The function "renderImage" in "typo3/sysext/fluid/Classes/ViewHelpers/MediaViewHelper.php" expects a fourth optional parameter "$fileExtension". As the function "renderImage" in "sms-responsive-images/Classes/ViewHelpers/MediaViewHelper.php" extends the main MediaViewHelper of fluid and calls its parent at the end, an error will be thrown, as this parameter is missing in the current development branch. 
This pull request adds the fourth optional parameter "$fileExtension" to the "renderImage" function in "sms-responsive-images/Classes/ViewHelpers/MediaViewHelper.php". 

Regards