### PR TITLE
[BUGFIX] Do not set empty crop in `$processingInstructions`

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -482,8 +482,10 @@ class ResponsiveImagesUtility implements SingletonInterface
             // Generate image
             $processingInstructions = [
                 'width' => $candidateWidth,
-                'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
             ];
+            if (!$cropArea->isEmpty()) {
+                $processingInstructions['crop'] = $cropArea->makeAbsoluteBasedOnFile($image);
+            }
             if (!empty($fileExtension)) {
                 $processingInstructions['fileExtension'] = $fileExtension;
             }
@@ -525,8 +527,10 @@ class ResponsiveImagesUtility implements SingletonInterface
 
         $processingInstructions = [
             'width' => $width,
-            'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
         ];
+        if (!$cropArea->isEmpty()) {
+            $processingInstructions['crop'] = $cropArea->makeAbsoluteBasedOnFile($image);
+        }
         if (!empty($fileExtension)) {
             $processingInstructions['fileExtension'] = $fileExtension;
         }


### PR DESCRIPTION
If there's no cropping configured, null is passed as configuration in $processingInstructions. This way, the image is not scaled at all.
The patch is setting `$processingInstructions['crop']` only if the configuration is *not* empty.

Fixes: #92