### PR TITLE
fix: Coerce `sizes` viewhelper argument to string (fixes #102)

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -188,7 +188,7 @@ final class ImageViewHelper extends AbstractTagBasedViewHelper
                     $this->arguments['srcset'],
                     $cropArea,
                     $focusArea,
-                    $this->arguments['sizes'],
+                    (string) $this->arguments['sizes'],
                     $this->tag,
                     $this->arguments['absolute'],
                     $this->arguments['lazyload'],

--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -271,7 +271,7 @@ final class MediaViewHelper extends AbstractTagBasedViewHelper
             $this->arguments['srcset'],
             $cropArea,
             $focusArea,
-            $this->arguments['sizes'],
+            (string) $this->arguments['sizes'],
             $this->tag,
             false,
             $this->arguments['lazyload'],


### PR DESCRIPTION
Fixes #102 