### PR TITLE
Cast srcset to string before trimming explode

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -459,7 +459,7 @@ class ResponsiveImagesUtility implements SingletonInterface
 
         // Convert srcset input to array
         if (!is_array($srcset)) {
-            $srcset = GeneralUtility::trimExplode(',', $srcset);
+            $srcset = GeneralUtility::trimExplode(',', (string)$srcset);
         }
 
         $images = [];


### PR DESCRIPTION
When using the following example, Fluid interprets the srcset as int, which breaks the trimExplode function.
```html
<sms:image
    image="{image.0}"
    breakpoints="{
    0: {
          'cropVariant': 'some_variant',
          'media': '(min-resolution: 2x)',
          'srcset': '600',
          'sizes': '300px, 100vw',
          },
[...]
```

This PR resolves this by casting the value to string before handing it over to the function